### PR TITLE
Add 'PATH' variable to Containerfile template

### DIFF
--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -1,6 +1,6 @@
 FROM scratch
 LABEL maintainer="Clement Verna <cverna@fedoraproject.org>"                    
-ENV DISTTAG=f{{ tag }}container FGC=f{{ tag }} FBR=f{{ tag }}
+ENV DISTTAG=f{{ tag }}container FGC=f{{ tag }} FBR=f{{ tag }} PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ADD {{ result_tar }} / 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
Fedora images hosted on registry.fedoraproject.org do not have a 'PATH' env variable defined on them. Their docker.io equivalents do. This causes subtle discrepancies when alternating between those two images (i.e. gcc failing to produce binaries when building a container image based on Fedora with kaniko). Let's add a 'PATH' variable to the template to deal with this inconsistency.